### PR TITLE
Fixes a crash when trying to access a `SpriteComponent`'s `.sprite()`

### DIFF
--- a/Sources/GateEngine/ECS/2D Specific/Sprite/SpriteComponent.swift
+++ b/Sources/GateEngine/ECS/2D Specific/Sprite/SpriteComponent.swift
@@ -49,7 +49,7 @@ public final class SpriteComponent: Component {
     internal var moveToNextAnimationIfNeeded: Bool = false
     public var activeAnimation: SpriteAnimation? {
         get {
-            if let index = self.activeAnimationIndex {
+            if let index = self.activeAnimationIndex, self.animations.count > index {
                 return self.animations[index]
             }
             return nil


### PR DESCRIPTION
The intent here is just to make sure there are elements in the animation array before trying to access them.

I considered changing this to a `guard`, which is how I would write it, but I opted for the smallest change.

Notably, I did also have to change my `RenderingSystem` subclass to check that the returned sprite's texture `isReady` before using it.